### PR TITLE
RET-1510 - Add support for sending mParticle events when an experimen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,6 @@ A kit takes care of initializing and forwarding information depending on what yo
 
 Please refer to installation instructions in the core mParticle Apple SDK [README](https://github.com/mParticle/mparticle-apple-sdk#get-the-sdk), or check out our [SDK Documentation](http://docs.mparticle.com/#sdk-documentation) site to learn more.
 
-
-## Static Library
-
-In order to use Apptimize you will need to comment out `use_frameworks!` in your `Podfile` (if you are using it) and include the `pos_install` script below:
-
-```ruby
-post_install do |pi|
-    pi.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            if target.name == "Apptimize"
-                config.build_settings["OTHER_LDFLAGS"]  = '$(inherited) "-ObjC"'
-            end
-        end
-    end
-end
-```
-
 ## Support
 
 Questions? Give us a shout at <support@mparticle.com>

--- a/mParticle-Apptimize.podspec
+++ b/mParticle-Apptimize.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Apptimize/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.12.3'
-    s.ios.dependency 'Apptimize', '2.18.0'
+    s.ios.dependency 'Apptimize', '2.18.2'
 end

--- a/mParticle-Apptimize/MPKitApptimize.m
+++ b/mParticle-Apptimize/MPKitApptimize.m
@@ -94,6 +94,7 @@ static NSString *const TRACK_EXPERIMENTS = @"trackExperiments";
 - (nonnull NSDictionary*)buildApptimizeOptions {
     NSMutableDictionary *o = [NSMutableDictionary new];
     [o setObject:[NSNumber numberWithBool:FALSE] forKey:ApptimizeEnableThirdPartyEventImportingOption];
+    [o setObject:[NSNumber numberWithBool:FALSE] forKey:ApptimizeEnableThirdPartyEventExportingOption];
     [self configureApptimizeDevicePairing:o];
     [self configureApptimizeDelayUntilTestsAreAvailable:o];
     [self configureApptimizeLogLevel:o];

--- a/mParticle-Apptimize/MPKitApptimize.m
+++ b/mParticle-Apptimize/MPKitApptimize.m
@@ -35,6 +35,7 @@ static NSString *const LOGOUT_TAG = @"logout";
 static NSString *const UPDATE_TAG = @"update";
 static NSString *const LTV_TAG = @"ltv";
 static NSString *const VIEWED_TAG_FORMAT = @"screenView %@";
+static NSString *const TRACK_EXPERIMENTS = @"trackExperiments";
 
 + (NSNumber *)kitCode {
     return @105;
@@ -96,6 +97,7 @@ static NSString *const VIEWED_TAG_FORMAT = @"screenView %@";
     [self configureApptimizeDevicePairing:o];
     [self configureApptimizeDelayUntilTestsAreAvailable:o];
     [self configureApptimizeLogLevel:o];
+    [self configureExperimentTracking];
     return o;
 }
 
@@ -128,6 +130,40 @@ static NSString *const VIEWED_TAG_FORMAT = @"screenView %@";
         value = [self.configuration objectForKey:key];
     }
     return value;
+}
+
+- (void) configureExperimentTracking {
+    BOOL enable = [self configValueForKey:TRACK_EXPERIMENTS];
+    if (enable) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(experimentDidGetViewed:)
+                                                     name:ApptimizeTestRunNotification
+                                                   object:nil];
+    }
+}
+
+- (void) experimentDidGetViewed:(NSNotification*)notification {
+    if (![notification.userInfo[ApptimizeTestFirstRunUserInfoKey] boolValue]) {
+        return;
+    }
+
+    // Apptimize doesn't notify with IDs, so we iterate over all experiments to find the matching one.
+    NSString *name = notification.userInfo[ApptimizeTestNameUserInfoKey];
+    NSString *variant = notification.userInfo[ApptimizeVariantNameUserInfoKey];
+    [[Apptimize testInfo] enumerateKeysAndObjectsUsingBlock:^(id key, id<ApptimizeTestInfo> experiment, BOOL *stop) {
+        BOOL match = [experiment.testName isEqualToString:name] && [experiment.enrolledVariantName isEqualToString:variant];
+        if (!match) {
+            return;
+        }
+        MPEvent *event = [[MPEvent alloc]initWithName:@"Experiment Viewed"
+                                                 type:MPEventTypeOther];
+        event.info = @{@"experimentId" : [experiment testID],
+                       @"experimentName" : [experiment testName],
+                       @"variationId" : [experiment enrolledVariantID],
+                       @"variationName" : [experiment enrolledVariantName]};
+        [[MParticle sharedInstance] logEvent:event];
+        *stop = YES;
+    }];
 }
 
 #pragma mark User attributes and identities


### PR DESCRIPTION
Add support for sending mParticle participation events when an experiment is viewed.

We really ought to have a flag to opt in or out of this, but that needs coordinating with mParticle to integrate it into their SDK. Either that or we should clarify whether their SDK allows for arbitrary key/value pairs to be passed down to SDK integrations.